### PR TITLE
Capturing the component to pass to the geolocation API

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -13,12 +13,13 @@ class App extends Component {
     }
 
     getLocation = () => {
+        let component = this;
         if(navigator.geolocation) {
             navigator.geolocation.getCurrentPosition(function(position) {
                 console.log(position);
                 console.log(position.coords.latitude);
                 console.log(position.coords.longitude);
-                this.setState({
+                component.setState({
                     lat: position.coords.latitude,
                     lng: position.coords.longitude,
                 });


### PR DESCRIPTION
The function passed to `getCurrentPosition` is not able to capture the value of the component as `this`. I am guessing that `this` must be shadowed even though it is set to null.

This change captures the component value into a variable called `component`, and then calls `setState` on that instead.